### PR TITLE
Add staff dashboard

### DIFF
--- a/frontendv4/src/pages/staff/StaffDashboardPage.jsx
+++ b/frontendv4/src/pages/staff/StaffDashboardPage.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { useAuth } from '../../hooks/useAuth';
+
+const StaffDashboardPage = () => {
+    const { user } = useAuth();
+
+    return (
+        <div className="p-6">
+            <h1 className="text-3xl font-bold text-gray-800 mb-4">Staff Dashboard</h1>
+            <div className="bg-white p-6 rounded-lg shadow-md">
+                <p className="text-lg text-gray-700">
+                    Welcome back, <span className="font-semibold">{user?.fullName || user?.email}</span>!
+                </p>
+                <p className="mt-2 text-gray-600">
+                    From here you can manage donation appointments and review emergency blood requests.
+                </p>
+            </div>
+        </div>
+    );
+};
+
+export default StaffDashboardPage;

--- a/frontendv4/src/routes/AppRoutes.jsx
+++ b/frontendv4/src/routes/AppRoutes.jsx
@@ -25,6 +25,7 @@ import AdminBloodInventoryPage from "../pages/admin/AdminBloodInventoryPage";
 import BloodCompatibilityCheckerPage from "../pages/BloodCompatibilityCheckerPage";
 import RequestDonationPage from '../pages/RequestDonationPage';
 import BloodRequestsPage from '../pages/BloodRequestsPage';
+import StaffDashboardPage from '../pages/staff/StaffDashboardPage';
 import ProtectedRoute from "./ProtectedRoute";
 import MainLayout from "../components/layout/MainLayout.jsx";
 
@@ -67,6 +68,7 @@ const AppRoutes = () => (
         {/* Staff Routes */}
         <Route element={<ProtectedRoute requiredRoles={['Staff', 'Admin']} />}>
             <Route path="/staff" element={<AdminLayout />}>
+                <Route index element={<StaffDashboardPage />} />
                 <Route path="donation-history" element={<AdminDonationHistoryPage />} />
                 <Route path="emergency-requests" element={<AdminEmergencyRequestsPage />} />
                 <Route path="blood-inventory" element={<AdminBloodInventoryPage />} />


### PR DESCRIPTION
## Summary
- add staff dashboard page
- add route for staff dashboard under `/staff`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_684cd7c7f1bc8326be0b4f6e2ab4d9d6